### PR TITLE
Refine Kelly sizing confidence blending

### DIFF
--- a/src/services/IntegratedPredictionSystem.ts
+++ b/src/services/IntegratedPredictionSystem.ts
@@ -86,9 +86,10 @@ export class IntegratedPredictionSystem {
     
     for (const tf of timeframes) {
       const signal = this.predictionModel.predict(features1m, tf)
+      const expectedReturnPercent = signal.expectedMove
       const kellySize = this.predictionModel.calculateKellySize(
         signal.confidence,
-        signal.expectedMove / 100
+        expectedReturnPercent
       )
       
       predictions[tf] = {
@@ -113,11 +114,12 @@ export class IntegratedPredictionSystem {
     
     // Determine market regime
     const marketRegime = this.determineMarketRegime(features1m)
-    
+
     // Calculate overall Kelly sizing
+    const strongestPrediction = predictions[strongestSignal]
     const kellySizing = this.predictionModel.calculateKellySize(
       overallConfidence,
-      predictions[strongestSignal].expectedMove / 100
+      strongestPrediction.expectedMove
     )
     
     // Get critical levels


### PR DESCRIPTION
## Summary
- blend the Kelly win probability between model confidence and the historical win rate instead of multiplying them
- normalize expected return inputs to percent units with a minimum edge before computing the Kelly ratio
- update the integrated prediction system to pass percent-based moves into the revised Kelly sizing helper

## Testing
- node -e "const confidence=0.7;const historical=0.27;const blended=0.6*confidence+0.4*historical;const p=Math.min(0.95,Math.max(0.05,blended));const q=1-p;const expectedReturn=2;const rawEdge=Math.abs(expectedReturn);const edgePercent=rawEdge<1?rawEdge*100:rawEdge;const minEdge=0.5;const b=Math.max(edgePercent,minEdge);const kellyFraction=(p*b-q)/b;const safetyFactor=0.25;const safeKelly=Math.max(0,Math.min(0.25,kellyFraction*safetyFactor));console.log({confidence,expectedReturn,blended,p,b,kellyFraction,safeKelly});"

------
https://chatgpt.com/codex/tasks/task_e_68dd297c91748327b505699be64ba8e6