### PR TITLE
Handle neutral ATR outputs gracefully

### DIFF
--- a/scripts/test-harness.ts
+++ b/scripts/test-harness.ts
@@ -592,14 +592,21 @@ export class HurricaneTestHarness {
     console.log('------|-------------|------------|-------|-----------|-----------|----------')
     
     for (const [tf, pred] of Object.entries(result.predictions)) {
+      const targetDisplay = pred.targets?.target !== undefined
+        ? `$${pred.targets.target.toFixed(2).padStart(8)}`
+        : '   --   ';
+      const stopDisplay = pred.stop !== null && pred.stop !== undefined
+        ? `$${pred.stop.toFixed(2)}`
+        : '--';
+
       console.log(
         `${tf.padEnd(5)} | ` +
         `${pred.direction.padEnd(11)} | ` +
         `${(pred.confidence * 100).toFixed(1).padStart(9)}% | ` +
         `${(pred.kellyFraction * 100).toFixed(1).padStart(5)}% | ` +
         `${pred.regime.padEnd(9)} | ` +
-        `$${pred.targets.target.toFixed(2).padStart(8)} | ` +
-        `$${pred.targets.stop.toFixed(2)}`
+        `${targetDisplay} | ` +
+        `${stopDisplay}`
       )
     }
     

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -14,9 +14,9 @@ export type PredictionResult = {
   side: "CALL"|"PUT"|"NONE",
   cone: Cone,
   entryPx: number,
-  targets: { target: number },  // or { long:number, short:number } if you prefer
-  stop: number,
+  targets: { target: number } | null,  // or { long:number, short:number } if you prefer
+  stop: number | null,
   rMultiple: { reward:number, risk:number, rr:number },
   size: number,
-  option: { side:"CALL"|"PUT"|"NONE", strike:number, dte:number }
+  option: { side:"CALL"|"PUT"|"NONE", strike:number|null, dte:number }
 };

--- a/src/logic/TargetsATR.ts
+++ b/src/logic/TargetsATR.ts
@@ -3,12 +3,24 @@ import type { TF } from "../core/types";
 const MULT = { "1m":1.5, "15m":2.0, "1h":3.0, "4h":4.0, "1d":5.0 } as const;
 const FLOOR = { "1m":0.0005, "15m":0.0015, "1h":0.0025, "4h":0.0040, "1d":0.0075 } as const;
 
-export function atrTargetsAndStops(series:any, fusedSide:number, entry:number, tf:TF){
+type ATRTargets = {
+  targets: { target: number };
+  stop: number;
+  rMultiple: { reward: number; risk: number; rr: number };
+  suggestedStrike: number;
+  rewardRisk: number;
+};
+
+export function atrTargetsAndStops(series:any, fusedSide:number, entry:number, tf:TF): ATRTargets | null {
   const atrRaw = series.tailATR;
   const px = entry ?? series.tailClose;
   const atr = Math.max(atrRaw, FLOOR[tf]*px);
   const m = MULT[tf];
-  const dir = fusedSide >= 0 ? +1 : -1;
+  const dir = fusedSide > 0 ? +1 : fusedSide < 0 ? -1 : 0;
+
+  if (dir === 0) {
+    return null;
+  }
 
   const target = px + dir * m * atr;
   const stop   = px - dir * 1.0 * atr;


### PR DESCRIPTION
## Summary
- return null from the ATR target generator when fused signals are flat and propagate neutral-friendly defaults through the prediction engine
- allow prediction types and downstream tooling to tolerate missing target, stop, and strike data so neutral forecasts no longer show phantom levels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd24b6d6e08327a8b97d80a0f6e5c6