### PR TITLE
Normalize option directions and improve Kelly sizing

### DIFF
--- a/src/api/enhanced-production.ts
+++ b/src/api/enhanced-production.ts
@@ -94,11 +94,16 @@ api.get('/predictions-with-options', async (c) => {
     const optionRecommendations = new Map<string, OptionRecommendation>()
     
     for (const [timeframe, prediction] of Object.entries(predictions.predictions)) {
+      const expectedReturn = typeof prediction.expectedReturn === 'number'
+        ? prediction.expectedReturn
+        : typeof prediction.expectedMove === 'number'
+          ? prediction.expectedMove / 100
+          : 0
       const recommendation = await optionsScanner.findBestOption(
         spotPrice,
         {
-          direction: prediction.direction,
-          expectedReturn: prediction.expectedReturn,
+          direction: EnhancedOptionsScanner.normalizeDirection(prediction.direction),
+          expectedReturn,
           confidence: prediction.confidence,
           timeframe
         },

--- a/src/api/quantconnect.ts
+++ b/src/api/quantconnect.ts
@@ -60,19 +60,20 @@ api.get('/predictions/current', async (c) => {
     
     // Process each timeframe
     for (const [tf, pred] of Object.entries(predictions.predictions)) {
+      const normalizedDirection = EnhancedOptionsScanner.normalizeDirection(pred.direction)
       const option = await optionsScanner.findBestOption(
         spotPrice,
         {
-          direction: pred.direction,
+          direction: normalizedDirection,
           expectedReturn: pred.expectedMove / 100,
           confidence: pred.confidence,
           timeframe: tf
         },
         optionChain
       )
-      
+
       qcFormat.timeframes[tf] = {
-        direction: pred.direction === 'BUY' ? 1 : pred.direction === 'SELL' ? -1 : 0,
+        direction: normalizedDirection === 'bullish' ? 1 : normalizedDirection === 'bearish' ? -1 : 0,
         confidence: pred.confidence,
         target_price: pred.targetPrice,
         stop_loss: pred.stopLoss,

--- a/src/models/OptionsScanner.ts
+++ b/src/models/OptionsScanner.ts
@@ -79,19 +79,41 @@ export class EnhancedOptionsScanner {
   /**
    * Find best option contract for given prediction
    */
+  static normalizeDirection(direction: string | undefined | null): 'bullish' | 'bearish' | 'neutral' {
+    if (!direction) return 'neutral'
+
+    const normalized = direction.toString().trim().toUpperCase()
+
+    if (['STRONG_BUY', 'BUY', 'BULLISH', 'LONG', 'CALL', 'UP'].includes(normalized)) {
+      return 'bullish'
+    }
+
+    if (['STRONG_SELL', 'SELL', 'BEARISH', 'SHORT', 'PUT', 'DOWN'].includes(normalized)) {
+      return 'bearish'
+    }
+
+    if (['NEUTRAL', 'HOLD', 'SIDEWAYS'].includes(normalized)) {
+      return 'neutral'
+    }
+
+    return 'neutral'
+  }
+
   async findBestOption(
     spotPrice: number,
     prediction: {
-      direction: 'bullish' | 'bearish' | 'neutral'
+      direction: string
       expectedReturn: number
       confidence: number
       timeframe: string
     },
     optionChain: OptionContract[]
   ): Promise<OptionRecommendation | null> {
-    if (prediction.direction === 'neutral') return null
+    const direction = EnhancedOptionsScanner.normalizeDirection(prediction.direction)
 
-    const isCall = prediction.direction === 'bullish'
+    if (direction === 'neutral') return null
+
+    const isCall = direction === 'bullish'
     
     // Filter option chain
     const filteredOptions = this.filterOptions(optionChain, isCall)


### PR DESCRIPTION
## Summary
- normalize Hurricane prediction directions before scoring options so bullish signals request calls
- ensure API fallbacks provide expected returns when only expected moves are available
- blend model confidence with historical hit-rate for Kelly sizing to avoid collapsing to zero

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd24af7a2483279f897212294ef55c