### PR TITLE
Enforce live data policy and add external integration checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ interface OptionRecommendation {
 2. **Alpha Vantage** (FALLBACK) - Backup data source
 3. **Synthetic Data** (LAST RESORT) - Generated data for continuity
 
+### Live Data Enforcement
+- Synthetic fallbacks are **disabled by default** through the new `DataSourceGuard`
+- Set `HURRICANE_REQUIRE_LIVE_DATA=true` (default) to enforce real market feeds
+- Development teams can temporarily allow mock data by setting `HURRICANE_ALLOW_SYNTHETIC=true`
+- Run `node scripts/live-integrity-check.mjs` to verify GitHub + Alpaca connectivity and ensure live data credentials are installed
+
 ## 🎨 User Guide
 
 ### Reading the Dashboard

--- a/scripts/live-integrity-check.mjs
+++ b/scripts/live-integrity-check.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Sanity check script that verifies the Hurricane stack is configured to run
+ * against real data sources and that external integrations (GitHub + Alpaca)
+ * are reachable. The script intentionally exits with a non-zero code when a
+ * requirement is not satisfied so it can be wired into CI pipelines.
+ */
+
+const requiredMarketKeys = ['POLYGON_API_KEY', 'ALPHA_VANTAGE_API_KEY']
+const requiredAlpacaKeys = ['ALPACA_API_KEY_ID', 'ALPACA_API_SECRET_KEY']
+const requiredGitHubVars = ['GITHUB_TOKEN', 'GITHUB_REPOSITORY']
+
+function assertEnvVars(names, label) {
+  const missing = names.filter((name) => !process.env[name] || process.env[name]?.trim() === '')
+  if (missing.length > 0) {
+    throw new Error(`Missing ${label} environment variables: ${missing.join(', ')}`)
+  }
+}
+
+function parseBoolean(value, defaultValue) {
+  if (value === undefined) return defaultValue
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false
+  return defaultValue
+}
+
+async function verifyGitHub() {
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.GITHUB_REPOSITORY
+
+  const response = await fetch(`https://api.github.com/repos/${repo}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'hurricane-live-integrity-check'
+    }
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`GitHub repository check failed (${response.status}): ${body}`)
+  }
+
+  return response.json()
+}
+
+async function verifyAlpaca() {
+  const baseUrl = process.env.ALPACA_API_BASE_URL ?? 'https://paper-api.alpaca.markets'
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}/v2/account`, {
+    headers: {
+      'APCA-API-KEY-ID': process.env.ALPACA_API_KEY_ID,
+      'APCA-API-SECRET-KEY': process.env.ALPACA_API_SECRET_KEY,
+      Accept: 'application/json'
+    }
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Alpaca connectivity check failed (${response.status}): ${body}`)
+  }
+
+  return response.json()
+}
+
+async function main() {
+  const allowSynthetic = parseBoolean(process.env.HURRICANE_ALLOW_SYNTHETIC, false)
+  const requireLiveData = parseBoolean(process.env.HURRICANE_REQUIRE_LIVE_DATA, true)
+
+  if (allowSynthetic || !requireLiveData) {
+    throw new Error(
+      'Synthetic data is currently allowed. Set HURRICANE_REQUIRE_LIVE_DATA=true (default) ' +
+        'and do not override with HURRICANE_ALLOW_SYNTHETIC=true when running production.'
+    )
+  }
+
+  assertEnvVars(requiredMarketKeys, 'market data')
+  assertEnvVars(requiredAlpacaKeys, 'Alpaca')
+  assertEnvVars(requiredGitHubVars, 'GitHub')
+
+  console.log('✅ Environment variables present. Checking external integrations...')
+
+  const [githubInfo, alpacaAccount] = await Promise.all([verifyGitHub(), verifyAlpaca()])
+
+  console.log(`🟢 GitHub repository accessible: ${githubInfo.full_name}`)
+  console.log(`🟢 Alpaca account status: ${alpacaAccount.status}`)
+  console.log('Hurricane integrity check completed successfully. Live data configuration verified.')
+}
+
+main().catch((error) => {
+  console.error('❌ Live integrity check failed:')
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})

--- a/src/market-data-enhanced.ts
+++ b/src/market-data-enhanced.ts
@@ -6,6 +6,7 @@
 
 import { type Candle } from './models/prediction'
 import { PolygonAPI } from './services/PolygonAPI'
+import { DataSourceGuard } from './services/DataSourceGuard'
 
 export class EnhancedMarketDataService {
   private polygonApi: PolygonAPI | null = null
@@ -26,8 +27,10 @@ export class EnhancedMarketDataService {
       console.log('📊 Alpha Vantage available as fallback')
     }
     
+    console.log(`🛡️ ${DataSourceGuard.describePolicy()}`)
+
     if (!polygonKey && !alphaVantageKey) {
-      console.warn('⚠️ No API keys provided, will use synthetic data only')
+      console.warn('⚠️ No API keys provided, synthetic fallback will trigger unless disabled by policy')
     }
   }
 
@@ -83,6 +86,8 @@ export class EnhancedMarketDataService {
   
   // Generate synthetic historical data for testing
   private generateSyntheticHistoricalData(date: string): any {
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.generateSyntheticHistoricalData')
+
     const basePrice = 580 + (Math.sin(Date.parse(date) / 86400000) * 10)
     const dayChange = (Math.random() - 0.5) * 5
     
@@ -209,6 +214,7 @@ export class EnhancedMarketDataService {
 
     // Final fallback: Synthetic data
     console.warn('⚠️ Using synthetic data (all APIs failed)')
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.getCurrentSPYQuote')
     const syntheticResult = {
       price: 420 + (Math.random() - 0.5) * 10,
       change: (Math.random() - 0.5) * 5,
@@ -277,6 +283,7 @@ export class EnhancedMarketDataService {
 
     // Fallback to synthetic data
     console.warn('⚠️ Generating synthetic historical data')
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.getHistoricalData')
     return this.generateSyntheticCandles(interval, outputSize === 'full' ? 500 : 100)
   }
 
@@ -301,6 +308,7 @@ export class EnhancedMarketDataService {
     }
 
     // Synthetic RSI
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.getRSI')
     const syntheticRSI = 50 + (Math.random() - 0.5) * 30
     this.setCache(cacheKey, syntheticRSI)
     return syntheticRSI
@@ -326,6 +334,7 @@ export class EnhancedMarketDataService {
     }
 
     // Synthetic MACD
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.getMACD')
     const syntheticMACD = {
       macd: (Math.random() - 0.5) * 2,
       signal: (Math.random() - 0.5) * 1.5,
@@ -356,6 +365,7 @@ export class EnhancedMarketDataService {
     }
 
     // Synthetic VIX
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.getVIX')
     const syntheticVIX = 15 + Math.random() * 10
     this.setCache(cacheKey, syntheticVIX)
     return syntheticVIX
@@ -363,6 +373,8 @@ export class EnhancedMarketDataService {
 
   // Generate synthetic candles when APIs fail
   private generateSyntheticCandles(interval: string, count: number): Candle[] {
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataService.generateSyntheticCandles')
+
     const candles: Candle[] = []
     const now = new Date()
     

--- a/src/models/EnhancedMarketData.ts
+++ b/src/models/EnhancedMarketData.ts
@@ -4,6 +4,7 @@
  */
 
 import { PolygonAPI } from '../services/PolygonAPI'
+import { DataSourceGuard } from '../services/DataSourceGuard'
 
 export interface MarketData {
   spy_price: number
@@ -65,8 +66,9 @@ export class EnhancedMarketDataGenerator {
         console.warn('⚠️ Falling back to synthetic data')
       }
     }
-    
+
     // Fallback to synthetic data
+    DataSourceGuard.ensureLiveData('EnhancedMarketDataGenerator.generateCurrentData')
     const syntheticData = this.generateSyntheticData()
     this.cache.set(cacheKey, { data: syntheticData, timestamp: Date.now() })
     return syntheticData
@@ -175,6 +177,7 @@ export class EnhancedMarketDataGenerator {
     movingAverages: { ma5: number; ma20: number; ma50: number; ma200: number }
   }> {
     if (!this.polygonApi) {
+      DataSourceGuard.ensureLiveData('EnhancedMarketDataGenerator.getTechnicalIndicators')
       // Return synthetic indicators
       return {
         rsi: 50 + (Math.random() - 0.5) * 30,

--- a/src/services/DataSourceGuard.ts
+++ b/src/services/DataSourceGuard.ts
@@ -1,0 +1,89 @@
+/**
+ * Utility that enforces whether the application is allowed to fall back to
+ * synthetic data. The default policy is to require live market data so that
+ * production runs always execute the full algorithm with real inputs.
+ */
+
+type EnvLike = Record<string, string | undefined>
+
+// Allow using process.env in strict TypeScript without pulling in Node types.
+declare const process: { env?: EnvLike } | undefined
+
+function collectEnvironment(): EnvLike {
+  const env: EnvLike = {}
+
+  if (typeof process !== 'undefined' && process?.env) {
+    Object.assign(env, process.env)
+  }
+
+  try {
+    const metaEnv = (import.meta as any)?.env as EnvLike | undefined
+    if (metaEnv) {
+      Object.assign(env, metaEnv)
+    }
+  } catch {
+    // Ignored – running in a non-Vite/Node environment.
+  }
+
+  return env
+}
+
+function parseBoolean(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined) {
+    return defaultValue
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false
+  }
+
+  return defaultValue
+}
+
+export class DataSourceGuard {
+  /**
+   * Returns true when synthetic fallbacks are explicitly allowed via
+   * environment variables.
+   */
+  static isSyntheticAllowed(): boolean {
+    const env = collectEnvironment()
+
+    const allowSynthetic = parseBoolean(env.HURRICANE_ALLOW_SYNTHETIC, false)
+    const requireLiveData = parseBoolean(env.HURRICANE_REQUIRE_LIVE_DATA, true)
+
+    if (allowSynthetic) {
+      return true
+    }
+
+    return !requireLiveData
+  }
+
+  /**
+   * Throws an error when synthetic data would be used while the guard
+   * requires live market inputs. The context message identifies which code
+   * path attempted to generate synthetic data.
+   */
+  static ensureLiveData(context: string): void {
+    if (!this.isSyntheticAllowed()) {
+      throw new Error(
+        `Synthetic data usage is disabled (${context}). ` +
+          'Provide live-market credentials (Polygon, Alpha Vantage, etc.) or set ' +
+          '`HURRICANE_REQUIRE_LIVE_DATA=false`/`HURRICANE_ALLOW_SYNTHETIC=true` if you intend to operate in a sandbox.'
+      )
+    }
+  }
+
+  /**
+   * Returns a human readable summary of the current policy – useful for
+   * logging in diagnostics.
+   */
+  static describePolicy(): string {
+    return this.isSyntheticAllowed()
+      ? 'Synthetic fallbacks enabled (development/testing mode).'
+      : 'Synthetic fallbacks disabled – live market data required.'
+  }
+}


### PR DESCRIPTION
## Summary
- add a DataSourceGuard utility and wire it into market data services so production runs require live inputs
- provide a live-integrity-check script that validates GitHub and Alpaca connectivity alongside required credentials
- document the new live data policy and verification workflow in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd46b513b88327a3ee2a2bd0fb4054