### PR TITLE
Refine Kelly payout ratio handling

### DIFF
--- a/src/services/IntegratedPredictionSystem.ts
+++ b/src/services/IntegratedPredictionSystem.ts
@@ -86,9 +86,12 @@ export class IntegratedPredictionSystem {
     
     for (const tf of timeframes) {
       const signal = this.predictionModel.predict(features1m, tf)
+      const expectedReturnPercent = signal.expectedMove
       const kellySize = this.predictionModel.calculateKellySize(
         signal.confidence,
-        signal.expectedMove / 100
+        expectedReturnPercent,
+        undefined,
+        signal.riskReward
       )
       
       predictions[tf] = {
@@ -113,11 +116,14 @@ export class IntegratedPredictionSystem {
     
     // Determine market regime
     const marketRegime = this.determineMarketRegime(features1m)
-    
+
     // Calculate overall Kelly sizing
+    const strongestPrediction = predictions[strongestSignal]
     const kellySizing = this.predictionModel.calculateKellySize(
       overallConfidence,
-      predictions[strongestSignal].expectedMove / 100
+      strongestPrediction.expectedMove,
+      undefined,
+      strongestPrediction.riskReward
     )
     
     // Get critical levels


### PR DESCRIPTION
## Summary
- blend Kelly probability inputs with model confidence while capping payout ratios between 1R and 5R
- normalize tiny ATR-derived edges into percent units only when needed and lean on the trade risk/reward ratio for sizing
- pass the per-timeframe risk/reward output through the integrated system so Kelly sizing reflects each trade setup

## Testing
- node - <<'NODE'
function calculateKellySize(confidence, expectedReturn, historicalWinRate = 0.27, riskReward){
  const blendedProbability = 0.6 * confidence + 0.4 * historicalWinRate;
  const p = Math.min(0.95, Math.max(0.05, blendedProbability));
  const q = 1 - p;
  const rawEdge = Math.abs(expectedReturn);
  const edgePercent = rawEdge < 0.01 ? rawEdge * 100 : rawEdge;
  const derivedPayout = edgePercent;
  const minPayout = 1.0;
  const maxPayout = 5.0;
  const payoutRatio = Math.max(
    minPayout,
    Math.min(maxPayout, riskReward && riskReward > 0 ? riskReward : derivedPayout)
  );
  const kellyFraction = (p * payoutRatio - q) / payoutRatio;
  const safetyFactor = 0.25;
  const safeKelly = Math.max(0, Math.min(0.25, kellyFraction * safetyFactor));
  return safeKelly;
}
console.log('bullish', calculateKellySize(0.7, 0.8, 0.27, 2.5));
console.log('fractional edge', calculateKellySize(0.55, 0.0035, 0.27, 1.8));
console.log('weak edge fallback', calculateKellySize(0.6, 0.15));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68dd297c91748327b505699be64ba8e6